### PR TITLE
FIX: placeholder 设置得比较混乱，导致出现loading...的现象

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-select",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "homepage": "https://github.com/mycolorway/simple-select",
   "authors": [
     "kshift <kshift.lv@gmail.com>"

--- a/lib/select.js
+++ b/lib/select.js
@@ -71,7 +71,7 @@ Select = (function(superClass) {
     this.el = $(this.opts.el).hide();
     this.el.data("select", this);
     this.select = $(Select._tpl.select).data("select", this).addClass(this.opts.cls).insertBefore(this.el);
-    this.input = $(Select._tpl.input).attr("placeholder", this.el.data('loading') || this._t('loading')).prependTo(this.select);
+    this.input = $(Select._tpl.input).attr("placeholder", this.opts.placeholder || this.el.data('placeholder') || "").prependTo(this.select);
     this.list = this.select.find(".select-list");
     this.requireSelect = true;
     items = this.el.find("option").map((function(_this) {
@@ -351,7 +351,6 @@ Select = (function(superClass) {
       return;
     }
     this.list.find(".loading, .select-item").remove();
-    this.input.attr("placeholder", this.el.data("placeholder") || this.opts.placeholder);
     for (j = 0, len = items.length; j < len; j++) {
       item = items[j];
       $itemEl = $(Select._tpl.item).data(item);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-select",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "a simple select plugin based on Simple Module",
   "main": "lib/select.js",
   "repository": {

--- a/spec/select-spec.coffee
+++ b/spec/select-spec.coffee
@@ -162,7 +162,20 @@ describe 'Simple Select', ->
     select.destroy()
     expect(selectEl.data('select')).not.toBe(select)
 
-    
+  it "should set placeholder by setting data-placeholder", ->
+    hint = "some hint text"
+    selectEl.data("placeholder", hint)
+    selectEl.appendTo("body")
+    select = simple.select
+      el: $("#select-one")
+    expect(select.input.attr("placeholder")).toBe(hint)
 
-    
-
+  it "should override data-placeholder by setting placeholder in opt", ->
+    hint = "some hint text"
+    anotherHint = "another hint text"
+    selectEl.data("placeholder", hint)
+    selectEl.appendTo("body")
+    select = simple.select
+      el: $("#select-one")
+      placeholder: anotherHint
+    expect(select.input.attr("placeholder")).toBe(anotherHint)

--- a/spec/select-spec.js
+++ b/spec/select-spec.js
@@ -160,7 +160,7 @@
       });
       return expect(selectEl.data('select')).toBe(select);
     });
-    return it("should destroy reference in el after destroy", function() {
+    it("should destroy reference in el after destroy", function() {
       var select;
       selectEl.appendTo("body");
       select = simple.select({
@@ -168,6 +168,28 @@
       });
       select.destroy();
       return expect(selectEl.data('select')).not.toBe(select);
+    });
+    it("should set placeholder by setting data-placeholder", function() {
+      var hint, select;
+      hint = "some hint text";
+      selectEl.data("placeholder", hint);
+      selectEl.appendTo("body");
+      select = simple.select({
+        el: $("#select-one")
+      });
+      return expect(select.input.attr("placeholder")).toBe(hint);
+    });
+    return it("should override data-placeholder by setting placeholder in opt", function() {
+      var anotherHint, hint, select;
+      hint = "some hint text";
+      anotherHint = "another hint text";
+      selectEl.data("placeholder", hint);
+      selectEl.appendTo("body");
+      select = simple.select({
+        el: $("#select-one"),
+        placeholder: anotherHint
+      });
+      return expect(select.input.attr("placeholder")).toBe(anotherHint);
     });
   });
 

--- a/src/select.coffee
+++ b/src/select.coffee
@@ -61,7 +61,7 @@ class Select extends SimpleModule
       .addClass(@opts.cls)
       .insertBefore @el
     @input = $(Select._tpl.input)
-      .attr("placeholder", @el.data('loading') || @_t('loading'))
+      .attr("placeholder", @opts.placeholder || @el.data('placeholder') || @el.data('loading') || @_t('loading'))
       .prependTo @select
     @list = @select.find ".select-list"
 
@@ -274,7 +274,6 @@ class Select extends SimpleModule
 
     return unless items.length > 0
     @list.find(".loading, .select-item").remove()
-    @input.attr("placeholder", @el.data("placeholder") || @opts.placeholder)
 
     for item in items
       $itemEl = $(Select._tpl.item).data(item)

--- a/src/select.coffee
+++ b/src/select.coffee
@@ -61,7 +61,7 @@ class Select extends SimpleModule
       .addClass(@opts.cls)
       .insertBefore @el
     @input = $(Select._tpl.input)
-      .attr("placeholder", @opts.placeholder || @el.data('placeholder') || @el.data('loading') || @_t('loading'))
+      .attr("placeholder", @opts.placeholder || @el.data('placeholder'))
       .prependTo @select
     @list = @select.find ".select-list"
 

--- a/src/select.coffee
+++ b/src/select.coffee
@@ -61,7 +61,7 @@ class Select extends SimpleModule
       .addClass(@opts.cls)
       .insertBefore @el
     @input = $(Select._tpl.input)
-      .attr("placeholder", @opts.placeholder || @el.data('placeholder'))
+      .attr("placeholder", @opts.placeholder || @el.data('placeholder') || "")
       .prependTo @select
     @list = @select.find ".select-list"
 


### PR DESCRIPTION
之前的placeholder设置的逻辑比较混乱

* 如果items为空  设置顺序为 'data-loading' -> @_t('loading')
* 如果items不为空 设置顺序为 'data-placeholder' -> @opts.placeholder

现在直接在一处设置placeholder，逻辑为

@opts.placeholder -> data-placeholder -> data-loading -> @_t('loading')

这里 data-loading 和 data-placeholder 有点重复了，是否可以只要一个？

[tower task](https://tower.im/projects/6d6ca827621042b59878b7d61c8e5681/todos/93e492fff64846d79e7305ce01fc38f4/)